### PR TITLE
Fixed build issue when kernel built with O=

### DIFF
--- a/arch/arm64/boot/dts/exynos/exynos9810-rmem.dtsi
+++ b/arch/arm64/boot/dts/exynos/exynos9810-rmem.dtsi
@@ -9,7 +9,6 @@
  * published by the Free Software Foundation.
  */
 
-#include "../../../../../include/generated/autoconf.h"
 #include <dt-bindings/soc/samsung/exynos-ss-table.h>
 
 / {


### PR DESCRIPTION
It doesn't look like this autoconf.h reference is adding much if anything.

The problem with it is though - if you build a kernel with O= (i.e. a different output dir) then the relative path no longer works. This essentially means I can't use ELS directly for building a recovery (e.g. TWRP) because they always specify a specific output dir for the kernel build.

This change resolves that issue but may not be the best fix. I'll leave that call up to you. 👍 