### PR TITLE
dts: Makefile: build rev26 dtb only for crownlte

### DIFF
--- a/arch/arm64/boot/dts/exynos/Makefile
+++ b/arch/arm64/boot/dts/exynos/Makefile
@@ -1,12 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0
-dtb-$(CONFIG_CAMERA_CROWN) += exynos9810-crownlte_eur_open_17.dtb \
-	exynos9810-crownlte_eur_open_18.dtb \
-	exynos9810-crownlte_eur_open_19.dtb \
-	exynos9810-crownlte_eur_open_21.dtb \
-	exynos9810-crownlte_eur_open_23.dtb \
-	exynos9810-crownlte_eur_open_24.dtb \
-	exynos9810-crownlte_eur_open_25.dtb \
-	exynos9810-crownlte_eur_open_26.dtb
+dtb-$(CONFIG_CAMERA_CROWN) += exynos9810-crownlte_eur_open_26.dtb
 
 
 always            := $(dtb-y) $(dtbo-y)


### PR DESCRIPTION
Other dtbs are unused and only inflate the size of the kernel. Only build the required rev26 dtb instead.